### PR TITLE
Force tmp to a version above 0.2.3 to deal with Arbitrary File Writing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
 	"dependencies": {
 		"@elgato/streamdeck": "^1.4.0",
 		"ws": "^8.18.3"
+	},
+	"resolutions": {
+		"tmp": ">=0.2.4"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tmp: '>=0.2.4'
+
 importers:
 
   .:
@@ -594,10 +597,6 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -688,9 +687,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1107,7 +1106,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.5
 
   fast-deep-equal@3.1.3: {}
 
@@ -1206,8 +1205,6 @@ snapshots:
   mkdirp@3.0.1: {}
 
   mute-stream@2.0.0: {}
-
-  os-tmpdir@1.0.2: {}
 
   path-parse@1.0.7: {}
 
@@ -1314,9 +1311,7 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
+  tmp@0.2.5: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
Resolves https://github.com/TeddiO/elgato-streamdeck-g502-battery-monitor/security/dependabot/5 which is caused by an exploit in the `tmp` package (included with Streamdeck). 